### PR TITLE
do not raise an exception when arg is too short for the format string.

### DIFF
--- a/mrblib/syslog.rb
+++ b/mrblib/syslog.rb
@@ -1,6 +1,6 @@
 module Syslog
   def self.log(priority, format, *arg)
-    Syslog._log0 priority, sprintf(format, *arg)
+    Syslog._log0 priority, (sprintf(format, *arg) rescue format)
   end
 
   def self.facility

--- a/test/syslog.rb
+++ b/test/syslog.rb
@@ -45,6 +45,14 @@ assert('Syslog.log with format') do
   line.include? "Syslog.log 1 2 3"
 end
 
+assert('Syslog.log with unexpected format string') do
+  Syslog.open("abc", Syslog::LOG_PERROR)
+  Syslog.log(Syslog::LOG_INFO, "Syslog.log %c %d %s")
+  Syslog.close
+
+  assert_true syslog_last_line.include?("Syslog.log %c %d %s")
+end
+
 assert('Syslog.opened?') do
   o0 = Syslog.opened?
   Syslog.open("abc", Syslog::LOG_PERROR)


### PR DESCRIPTION
Just print that format string instead.  This makes the API of
Syslog.log incompatible to MRI (which raises an ArgumentError
exception) but more resistant to programming errors and format
string vulnerabilities.